### PR TITLE
Update Twitter + GitHub header links' alt + title attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,8 @@
       </ul>
 
       <ul class="nav-social">
-        <li class="nav-social--item float-right"><a href="https://twitter.com/mozillavr/" class="social__link social__link--github link--borderless"><img class="icon icon--social" src="assets/img/icon-twitter-black.svg" alt="GitHub" title="GitHub"></a></li>
-        <li class="nav-social--item float-right"><a href="https://github.com/MozVR/" class="social__link social__link--twitter link--borderless"><img class="icon icon--social" src="assets/img/icon-github-black.svg" alt="Twitter" title="Twitter"></a></li>
+        <li class="nav-social--item float-right"><a href="https://twitter.com/mozillavr/" class="social__link social__link--twitter link--borderless"><img class="icon icon--social" src="assets/img/icon-twitter-black.svg" alt="Twitter" title="Twitter"></a></li>
+        <li class="nav-social--item float-right"><a href="https://github.com/MozVR/" class="social__link social__link--github link--borderless"><img class="icon icon--social" src="assets/img/icon-github-black.svg" alt="GitHub" title="GitHub"></a></li>
       </ul>
     </nav>
 


### PR DESCRIPTION
Just noticed the `alt` and `title` attributes for the GitHub and Twitter links in the header are reversed:

![123](https://cloud.githubusercontent.com/assets/121322/16101084/c2422f12-3317-11e6-9fc4-0d1b7d29ae82.gif)

Patch submitted from virtual reality!

Cheers,
  Lee :beers: